### PR TITLE
chaos: Rename registerPlugin method to load

### DIFF
--- a/packages/@pluggable-io/core/src/models.spec.ts
+++ b/packages/@pluggable-io/core/src/models.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { RegistoryBase } from './models.js'
-import { PluginAlreadyRegisteredError, PluginNotRegisteredError } from './types.js'
+import { PluginAlreadyLoadedError, PluginNotLoadedError } from './types.js'
 
 describe('RegistoryBase', () => {
   let registory: RegistoryBase<{
@@ -9,35 +9,35 @@ describe('RegistoryBase', () => {
   beforeEach(async () => {
     registory = new RegistoryBase()
   })
-  describe('registerPlugin function', () => {
-    it('should register a plugin', () => {
+  describe('load method', () => {
+    it('should load a plugin', () => {
       const plugin = {
         build: async () => ({
           test: 'test',
         }),
       }
-      registory.registerPlugin('test:', plugin)
+      registory.load('test:', plugin)
       expect(registory.plugins.get('test:')).toBe(plugin)
     })
 
-    it('should throw an error if a plugin is already registered', () => {
+    it('should throw an error if a plugin is already loaded', () => {
       const plugin = {
         build: async () => ({
           test: 'test',
         }),
       }
-      registory.registerPlugin('test:', plugin)
-      expect(() => registory.registerPlugin('test:', plugin)).toThrow(PluginAlreadyRegisteredError)
+      registory.load('test:', plugin)
+      expect(() => registory.load('test:', plugin)).toThrow(PluginAlreadyLoadedError)
     })
   })
-  describe('from function', () => {
+  describe('from method', () => {
     it('should return an instance of plugin', async () => {
       const plugin = {
         build: async () => ({
           test: 'test',
         }),
       }
-      registory.registerPlugin('test:', plugin)
+      registory.load('test:', plugin)
       const instance = await registory.from('test://')
       expect(instance).toStrictEqual({
         test: 'test',
@@ -48,38 +48,38 @@ describe('RegistoryBase', () => {
       await expect(registory.from('invalid')).rejects.toThrow(TypeError)
     })
 
-    it('should throw an error if no plugin is registered', async () => {
-      await expect(registory.from('not-registerd://')).rejects.toThrow(PluginNotRegisteredError)
+    it('should throw an error if no plugin is loaded', async () => {
+      await expect(registory.from('not-loaded://')).rejects.toThrow(PluginNotLoadedError)
     })
 
-    it('should not throw an error if no plugin is registered but PLUGIN_PLUG_AND_PLAY is set and the plugin is not registered', async () => {
-      registory.PLUGIN_PLUG_AND_PLAY['not-registerd:'] = async () => {
-        registory.registerPlugin('not-registerd:', {
+    it('should not throw an error if no plugin is loaded but PLUGIN_PLUG_AND_PLAY is set and the plugin is not loaded', async () => {
+      registory.PLUGIN_PLUG_AND_PLAY['not-loaded:'] = async () => {
+        registory.load('not-loaded:', {
           build: async () => ({
             test: 'test',
           }),
         })
       }
-      await expect(registory.from('not-registerd://')).resolves.toStrictEqual({
+      await expect(registory.from('not-loaded://')).resolves.toStrictEqual({
         test: 'test',
       })
     })
 
-    it('shold throw an error if no plugin is registered but PLUGIN_PLUG_AND_PLAY is set, but failed to execute PLUGIN_PLUG_AND_PLAY', async () => {
-      registory.PLUGIN_PLUG_AND_PLAY['not-registerd:'] = async () => {
-        registory.registerPlugin('not-registerd:', {
+    it('shold throw an error if no plugin is loaded but PLUGIN_PLUG_AND_PLAY is set, but failed to execute PLUGIN_PLUG_AND_PLAY', async () => {
+      registory.PLUGIN_PLUG_AND_PLAY['not-loaded:'] = async () => {
+        registory.load('not-loaded:', {
           build: async () => ({
             test: 'test',
           }),
         })
         throw new Error('test')
       }
-      await expect(registory.from('not-registerd://')).rejects.toThrow(PluginNotRegisteredError)
+      await expect(registory.from('not-loaded://')).rejects.toThrow(PluginNotLoadedError)
 
-      // Check plugin is not registered
-      expect(registory.plugins.has('not-registerd:')).toBe(false)
+      // Check plugin is not loaded
+      expect(registory.plugins.has('not-loaded:')).toBe(false)
       // Check if PLUGIN_PLUG_AND_PLAY is removed
-      expect(registory.PLUGIN_PLUG_AND_PLAY['not-registerd:']).toBe(undefined)
+      expect(registory.PLUGIN_PLUG_AND_PLAY['not-loaded:']).toBe(undefined)
     })
   })
 })

--- a/packages/@pluggable-io/core/src/models.ts
+++ b/packages/@pluggable-io/core/src/models.ts
@@ -1,4 +1,4 @@
-import { PluginAlreadyRegisteredError, PluginNotRegisteredError, Registory, ResourcePlugin } from './types.js'
+import { PluginAlreadyLoadedError, PluginNotLoadedError, Registory, ResourcePlugin } from './types.js'
 
 /**
  * A registry for resources.
@@ -10,15 +10,15 @@ export class RegistoryBase<T> implements Registory<T> {
 
   plugins = new Map<string, ResourcePlugin<T>>()
 
-  registerPlugin(protocol: string, plugin: ResourcePlugin<T>) {
+  load(protocol: string, plugin: ResourcePlugin<T>) {
     if (this.plugins.has(protocol))
-      throw new PluginAlreadyRegisteredError(`Plugin for protocol "${protocol}" already registered`)
+      throw new PluginAlreadyLoadedError(`Plugin for protocol "${protocol}" already loaded`)
     this.plugins.set(protocol, plugin)
   }
 
   async _from(url: URL): Promise<T> {
     const plugin = this.plugins.get(url.protocol)
-    if (!plugin) throw new PluginNotRegisteredError(`No plugin registered for protocol "${url.protocol}"`)
+    if (!plugin) throw new PluginNotLoadedError(`No plugin loaded for protocol "${url.protocol}"`)
     return plugin.build(url)
   }
 
@@ -27,14 +27,14 @@ export class RegistoryBase<T> implements Registory<T> {
     try {
       return await this._from(url_)
     } catch (error) {
-      if (error instanceof PluginNotRegisteredError) {
+      if (error instanceof PluginNotLoadedError) {
         if (url_.protocol in this.PLUGIN_PLUG_AND_PLAY) {
           try {
             await this.PLUGIN_PLUG_AND_PLAY[url_.protocol]()
           } catch (error2) {
             delete this.PLUGIN_PLUG_AND_PLAY[url_.protocol]
             this.plugins.delete(url_.protocol)
-            new PluginNotRegisteredError(`Tried Plug and Play for "${url_.protocol}", but it failed.`, {
+            new PluginNotLoadedError(`Tried Plug and Play for "${url_.protocol}", but it failed.`, {
               cause: new AggregateError([error, error2]),
             })
           }

--- a/packages/@pluggable-io/core/src/types.ts
+++ b/packages/@pluggable-io/core/src/types.ts
@@ -1,18 +1,18 @@
 /**
- * Error thrown when a plugin is not registerd.
+ * Error thrown when the corresponding plugin for the schema is not loaded.
  */
-export class PluginNotRegisteredError extends Error {
+export class PluginNotLoadedError extends Error {
   static {
-    this.prototype.name = 'PluginNotRegisteredError'
+    this.prototype.name = 'PluginNotLoadedError'
   }
 }
 
 /**
- * Error thrown when a plugin is already registered.
+ * Error thrown when a plugin corresponding to the schema has already been loaded.
  */
-export class PluginAlreadyRegisteredError extends Error {
+export class PluginAlreadyLoadedError extends Error {
   static {
-    this.prototype.name = 'PluginAlreadyRegisteredError'
+    this.prototype.name = 'PluginAlreadyLoadedError'
   }
 }
 
@@ -38,27 +38,27 @@ export interface Registory<T> {
   PLUGIN_PLUG_AND_PLAY: Record<string, () => Promise<any>>
 
   /**
-   * Register a plugin
-   * @param protocol The protocol to register for
-   * @param plugin The plugin to register
-   * @throws {PluginAlreadyRegisteredError} If a plugin is already registered for the scheme
+   * Load a plugin
+   * @param protocol The protocol to load for
+   * @param plugin The plugin to load
+   * @throws {PluginAlreadyLoadedError} If a plugin is already loaded for the scheme
    * @example
    * ```ts
    * const registory = new Registory();
    *
-   * registory.registerPlugin('sample:', {
+   * registory.load('sample:', {
    *    async build(url) {
    *     return new SampleStorage(url);
    *   }
    * })
    * ```
    */
-  registerPlugin(protocol: string, plugin: ResourcePlugin<T>): void
+  load(protocol: string, plugin: ResourcePlugin<T>): void
   /**
    * Build an instance from a URL
    * @param url The URL to build from
    * @returns The built instance
-   * @throws {PluginNotRegisteredError} If no plugin is registered for the protocol
+   * @throws {PluginNotLoadedError} If no plugin is loaded for the protocol
    * @throws {TypeError} If url is not a valid URL
    */
   from(url: string): Promise<T>

--- a/packages/@pluggable-io/logger-plugin-console/src/pnp.ts
+++ b/packages/@pluggable-io/logger-plugin-console/src/pnp.ts
@@ -21,7 +21,7 @@ declare module '@pluggable-io/logger' {
   }
 }
 
-Logger.registerPlugin('console:', {
+Logger.load('console:', {
   async build(url) {
     return new ConsoleLoggerAddapter(url.toString())
   },

--- a/packages/@pluggable-io/logger-plugin-memory/src/pnp.ts
+++ b/packages/@pluggable-io/logger-plugin-memory/src/pnp.ts
@@ -30,7 +30,7 @@ declare module '@pluggable-io/logger' {
   }
 }
 
-Logger.registerPlugin('memory:', {
+Logger.load('memory:', {
   async build(url) {
     return new MemoryLoggerAdapter(url.toString())
   },

--- a/packages/@pluggable-io/logger-plugin-null/src/pnp.ts
+++ b/packages/@pluggable-io/logger-plugin-null/src/pnp.ts
@@ -30,7 +30,7 @@ declare module '@pluggable-io/logger' {
   }
 }
 
-Logger.registerPlugin('null:', {
+Logger.load('null:', {
   async build(url) {
     return new NullLoggerAdapter(url.toString())
   },

--- a/packages/@pluggable-io/storage-plugin-file/src/pnp.ts
+++ b/packages/@pluggable-io/storage-plugin-file/src/pnp.ts
@@ -41,4 +41,4 @@ declare module '@pluggable-io/storage' {
   }
 }
 
-Storage.registerPlugin(DEFAULT_SCHEMA, new FileSystemStoragePlugin())
+Storage.load(DEFAULT_SCHEMA, new FileSystemStoragePlugin())

--- a/packages/@pluggable-io/storage-plugin-gs/src/pnp.ts
+++ b/packages/@pluggable-io/storage-plugin-gs/src/pnp.ts
@@ -10,4 +10,4 @@ declare module '@pluggable-io/storage' {
   }
 }
 
-Storage.registerPlugin('gs:', new GoogleCloudStoragePlugin())
+Storage.load('gs:', new GoogleCloudStoragePlugin())

--- a/packages/@pluggable-io/storage-plugin-memory/src/pnp.ts
+++ b/packages/@pluggable-io/storage-plugin-memory/src/pnp.ts
@@ -21,4 +21,4 @@ declare module '@pluggable-io/storage' {
   }
 }
 
-Storage.registerPlugin('memory:', new MemoryStoragePlugin())
+Storage.load('memory:', new MemoryStoragePlugin())

--- a/packages/@pluggable-io/storage/src/model.spec.ts
+++ b/packages/@pluggable-io/storage/src/model.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Storage, StorageRegistory } from './models.js'
-import { PluginNotRegisteredError } from '@pluggable-io/core'
+import { PluginNotLoadedError } from '@pluggable-io/core'
 
 describe('StorageRegistory', () => {
   let registyory: StorageRegistory
@@ -14,7 +14,7 @@ describe('StorageRegistory', () => {
       open: vi.fn(),
       list: vi.fn(),
     }
-    registyory.registerPlugin('test:', {
+    registyory.load('test:', {
       async build() {
         return storage
       },
@@ -30,8 +30,8 @@ describe('StorageRegistory', () => {
       expect(storage.open).toBeCalledWith('/package.json')
     })
 
-    it('should throw an error if the scheme is not registered', async () => {
-      await expect(registyory.open('unknown://origin/package.json')).rejects.toThrow(PluginNotRegisteredError)
+    it('should throw an error if the scheme is not loaded', async () => {
+      await expect(registyory.open('unknown://origin/package.json')).rejects.toThrow(PluginNotLoadedError)
     })
   })
 })

--- a/packages/@pluggable-io/storage/src/models.ts
+++ b/packages/@pluggable-io/storage/src/models.ts
@@ -75,7 +75,7 @@ export interface StorageStatic extends Registory<Storage> {
   /**
    * Open a file.
    * @param url URI of the file.
-   * @throws {PluginNotInstalledError} if the scheme is not registered.
+   * @throws {PluginNotInstalledError} if the scheme is not loaded.
    * @example
    * ```ts
    * const file = await Storage.open('fs://./package.json');


### PR DESCRIPTION
### Background

Registry has a `registerPlugin(plugin: Plugin)` method.

From an English point of view, it seems natural to think that "Registry loads Plugin".

#### Reference

- https://dev.mysql.com/doc/refman/8.0/en/plugin-loading.html
- https://book.cakephp.org/3/en/plugins.html
- https://www.npmjs.com/package/load-plugin

### Summary

Rename the `registerPlugin` method to the `load` method.